### PR TITLE
Add local mock financial service

### DIFF
--- a/app/tools/clientview_financials.py
+++ b/app/tools/clientview_financials.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pandas as pd
 from fastmcp import Context
 from typing import Optional, Dict, Any, List, Type, ClassVar
@@ -12,6 +13,9 @@ from app.registry.tools import register_tool
 from app.utils.tool_wrappers import llm_enhance_wrapper
 
 logger = logging.getLogger('mcp_server.tools.clientview_financials')
+
+# Base URL for ClientView endpoints. Default to local mock server.
+BASE_URL = os.getenv("CLIENTVIEW_BASE_URL", "http://localhost:8001")
 
 ###################
 # Enum Definitions
@@ -318,7 +322,7 @@ class RisersDecliners(BaseFinancialModel):
     Model for retrieving top clients by revenue.
     """
     # API endpoint
-    _endpoint_url: ClassVar[str] = "https://queryservice.cfk.devfg.rbc.com/procedure/memsql__client1__getTopClients"
+    _endpoint_url: ClassVar[str] = f"{BASE_URL}/procedure/memsql__client1__getTopClients"
     
     # Display column mapping - updated to include interaction data
     _display_columns: ClassVar[Dict[str, str]] = {
@@ -355,7 +359,7 @@ class ClientValueByTimePeriod(BaseFinancialModel):
     Model for retrieving client value by time period.
     """
     # API endpoint
-    _endpoint_url: ClassVar[str] = "https://queryservice.cfk.devfg.rbc.com/procedure/memsql__client1__getRevenueTotalByTimePeriod"
+    _endpoint_url: ClassVar[str] = f"{BASE_URL}/procedure/memsql__client1__getRevenueTotalByTimePeriod"
     
     # Display column mapping - updated to include interaction data
     _display_columns: ClassVar[Dict[str, str]] = {
@@ -389,7 +393,7 @@ class ClientValueByProduct(BaseFinancialModel):
     Model for retrieving client value by product.
     """
     # API endpoint
-    _endpoint_url: ClassVar[str] = "https://queryservice.cfk.devfg.rbc.com/procedure/memsql__client1__getClientValueRevenueByProduct"
+    _endpoint_url: ClassVar[str] = f"{BASE_URL}/procedure/memsql__client1__getClientValueRevenueByProduct"
     
     # Display column mapping - updated to include interaction data
     _display_columns: ClassVar[Dict[str, str]] = {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples
+
+This directory contains helper scripts for running the MCP server locally.
+
+## Dummy Financial Server
+
+`dummy_financial_server.py` provides mock endpoints for the ClientView financial
+tools. It hosts three in-memory tables with sample data so the tools can be
+tested without access to corporate services.
+
+### Running the Server
+
+```bash
+uvicorn examples.dummy_financial_server:app --host 0.0.0.0 --port 8001
+```
+
+Set the `CLIENTVIEW_BASE_URL` environment variable so the tools point to this
+server:
+
+```bash
+export CLIENTVIEW_BASE_URL="http://localhost:8001"
+```
+
+After starting the server and setting the environment variable, calls to the
+financial tools will return the dummy data.

--- a/examples/dummy_financial_server.py
+++ b/examples/dummy_financial_server.py
@@ -1,0 +1,77 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Any
+import random
+
+app = FastAPI(title="Dummy Financial Service")
+
+class RequestPayload(BaseModel):
+    appCode: str
+    values: List[Any]
+
+# In-memory tables
+TOP_CLIENTS = []
+REVENUE_BY_TIME = []
+CLIENT_VALUE_BY_PRODUCT = []
+
+REGIONS = ["CAN", "USA", "EUR", "APAC", "LATAM", "OTHER"]
+FOCUS_LISTS = ["Focus40", "FS30", "Corp100"]
+PRODUCTS = ["Bonds", "Equities", "FX", "Derivatives", "Commodities"]
+
+
+def _generate_tables():
+    random.seed(0)
+    for i in range(150):
+        TOP_CLIENTS.append({
+            "ClientName": f"Client {i}",
+            "ClientCDRID": 1000 + i,
+            "RevenueYTD": round(random.uniform(1_000_000, 10_000_000), 2),
+            "RegionName": random.choice(REGIONS),
+            "FocusList": random.choice(FOCUS_LISTS),
+            "InteractionCMOCYTD": random.randint(0, 20),
+            "InteractionGMOCYTD": random.randint(0, 20),
+            "InteractionYTD": random.randint(0, 40),
+            "InteractionCMOCPrevYTD": random.randint(0, 20),
+            "InteractionGMOCPrevYTD": random.randint(0, 20),
+            "InteractionPrevYTD": random.randint(0, 40),
+        })
+
+        REVENUE_BY_TIME.append({
+            "ClientName": f"Client {i}",
+            "ClientCDRID": 1000 + i,
+            "RevenueYTD": round(random.uniform(1_000_000, 10_000_000), 2),
+            "RevenuePrevYTD": round(random.uniform(500_000, 9_000_000), 2),
+            "InteractionCMOCYTD": random.randint(0, 20),
+            "InteractionGMOCYTD": random.randint(0, 20),
+            "InteractionYTD": random.randint(0, 40),
+            "TimePeriodList": [2023, 2024, 2025],
+            "TimePeriodCategory": random.choice(["FY", "CY"]),
+        })
+
+        CLIENT_VALUE_BY_PRODUCT.append({
+            "ProductName": random.choice(PRODUCTS),
+            "RevenueYTD": round(random.uniform(500_000, 5_000_000), 2),
+            "RevenuePrevYTD": round(random.uniform(500_000, 5_000_000), 2),
+            "ProductID": 2000 + i,
+            "ProductHierarchyDepth": random.randint(1, 3),
+            "ParentProductID": random.randint(1000, 1999),
+            "TimePeriodList": [2023, 2024, 2025],
+        })
+
+_generate_tables()
+
+@app.post("/procedure/memsql__client1__getTopClients")
+def get_top_clients(_: RequestPayload):
+    return {"status": "success", "data": TOP_CLIENTS}
+
+@app.post("/procedure/memsql__client1__getRevenueTotalByTimePeriod")
+def get_revenue_by_time(_: RequestPayload):
+    return {"status": "success", "data": REVENUE_BY_TIME}
+
+@app.post("/procedure/memsql__client1__getClientValueRevenueByProduct")
+def get_client_value_by_product(_: RequestPayload):
+    return {"status": "success", "data": CLIENT_VALUE_BY_PRODUCT}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary
- add base URL env var for financial endpoints
- include a FastAPI dummy server with fake tables
- document how to run the mock server

## Testing
- `python -m py_compile app/tools/clientview_financials.py examples/dummy_financial_server.py`
