### PR TITLE
Update README spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The system follows a layered architecture:
 
 ## Agent Registration
 
-The system supports registration of external agents, each with their own tools, resources, and prompts.
+The system supports registration of external agents, each with their own tools,  resources, and prompts.
 
 ### How to Register an Agent
 


### PR DESCRIPTION
## Summary
- adjust spacing in agent registration section of README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*