### PR TITLE
Remove optional rbc_security imports

### DIFF
--- a/app/mcp_bridge.py
+++ b/app/mcp_bridge.py
@@ -10,14 +10,11 @@ import time
 import hashlib
 from typing import Dict, Any, List, Optional
 
-from rbc_security import enable_certs
-
 from .config import config
 from .mcp_server import mcp
 from app.utils.parameter_extractor import extract_parameters_with_llm
 
 logger = logging.getLogger("mcp_server.bridge")
-enable_certs()
 
 
 class MCPBridge:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,13 @@ dependencies = [
     "pandas>=2.0.0",
     "python-dotenv>=1.0.0",
     "cohere>=4.0.0",
-    "click>=8.0.0"
+    "click>=8.0.0",
+    "markdown",
+    "beautifulsoup4",
+    "python-multipart>=0.0.18",
+    "aiohttp>=3.9.0",
+    "python-jose[cryptography]>=3.3.0",
+    "passlib[bcrypt]>=1.7.4"
 ]
 requires-python = ">=3.9"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,10 @@ pydantic>=2.5.3
 cohere>=4.37
 httpx>=0.26.0
 redis==5.0.1
-python-multipart==0.0.18
 fastmcp>=0.1.0
 aiohttp>=3.9.0
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
-python-multipart>=0.0.6 
+python-multipart>=0.0.18
+markdown
+beautifulsoup4

--- a/tests/test_compass_index_setup.py
+++ b/tests/test_compass_index_setup.py
@@ -2,17 +2,14 @@ import asyncio
 import logging
 import os
 from dotenv import load_dotenv
-from rbc_security import enable_certs
-import os 
 import sys
 from pathlib import Path
 
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent))
 
-# Load environment variables and certs
+# Load environment variables
 load_dotenv()
-enable_certs()
 
 # Logging setup
 logging.basicConfig(level=logging.INFO)

--- a/tests/test_compass_index_single_tool.py
+++ b/tests/test_compass_index_single_tool.py
@@ -2,16 +2,14 @@ import asyncio
 import logging
 import os
 from dotenv import load_dotenv
-from rbc_security import enable_certs
 import sys
 from pathlib import Path
 
 # Add project root to import path
 sys.path.append(str(Path(__file__).parent.parent))
 
-# Load env and enable certs
+# Load environment variables
 load_dotenv()
-enable_certs()
 
 import app.main
 

--- a/tests/test_compass_search.py
+++ b/tests/test_compass_search.py
@@ -6,10 +6,8 @@ from dotenv import load_dotenv
 # Fix the import path
 sys.path.append(str(Path(__file__).parent.parent))
 
-# Load environment variables and enable certs
+# Load environment variables
 load_dotenv()
-from rbc_security import enable_certs
-enable_certs()
 
 from app.config import config
 from cohere_compass.clients.compass import CompassClient


### PR DESCRIPTION
## Summary
- delete all `rbc_security` imports and calls
- clean up tests to only load environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', 'fastmcp', 'httpx', 'markdown', etc.)*