### PR TITLE
Refactor imports from mcp_server_old

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -195,12 +195,13 @@ def crm_mcp():
 
         click.echo(click.style("Starting CRM MCP server in stdio mode...", fg='yellow'))
 
-        # Import and run the MCP server
-        from app.mcp_server_old import main as mcp_main
+        # Import MCP server components
+        from app.mcp_server import mcp, process_message
+        from app.stdio_handler import run_stdio_mode
         import asyncio
 
-        # Run the MCP server
-        asyncio.run(mcp_main())
+        # Run the MCP server in STDIO mode
+        asyncio.run(run_stdio_mode(mcp, process_message))
     except Exception as e:
         click.echo(click.style(f"Error running CRM MCP server: {str(e)}", fg='red'), err=True)
         sys.exit(1)

--- a/app/client.py
+++ b/app/client.py
@@ -359,7 +359,7 @@ class MCPClient:
                     for attempt in range(3):  # Up to 3 attempts
                         try:
                             # Execute tool through the MCP server
-                            from .mcp_server_old import mcp
+                            from app.mcp_server import mcp
 
                             # Create a mock context for the tool
                             from .registry import tool_registry, resource_registry, prompt_registry

--- a/app/mcp_bridge.py
+++ b/app/mcp_bridge.py
@@ -33,7 +33,7 @@ import datetime
 import json
 from rbc_security import enable_certs
 from .config import config
-from .mcp_server_old import mcp
+from app.mcp_server import mcp
 from app.utils.parameter_extractor import extract_parameters_with_llm, _call_llm
 from .results_coordinator import ResultsCoordinator
 from .fallback_handler import FallbackHandler


### PR DESCRIPTION
## Summary
- switch old MCP server imports to `app.mcp_server`
- update CLI `crm-mcp` command to use `run_stdio_mode`

## Testing
- `pytest -q` *(fails: command not found)*