### PR TITLE
Update README with docs link and chaining graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The system follows a layered architecture:
    - Web interface for user interaction
    - Sends messages to the MCP client
 
-2. **MCP Client (ui/mcp/client.py)**
+2. **MCP Client (mcp_client.py)**
    - Processes user messages
    - Sends requests to the MCP server
    - Handles context retrieval from Cohere
@@ -76,9 +76,24 @@ The system follows a layered architecture:
 6. Response is returned through the chain
 7. Response is displayed in Chainlit UI
 
+Example tool chaining:
+
+```
+User Input
+   |
+   v
+MCP Server
+   |
+   v
+[Tool A] -> [Tool B] -> [Tool C]
+   |
+   v
+Response
+```
+
 ## Agent Registration
 
-The system supports registration of external agents, each with their own tools,  resources, and prompts.
+The system supports registration of external agents, each with their own tools,  resources, and prompts. See [docs/README.md](docs/README.md) for additional documentation.
 
 ### How to Register an Agent
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# MCP Server Documentation
+
+This directory contains additional documentation for the MCP Server.
+
+- [system_architecture.md](system_architecture.md) - Overview of components and data flow.
+- [code_walkthrough.md](code_walkthrough.md) - Explanation of key modules.
+- [docker_usage.md](docker_usage.md) - Instructions for building and running the container image.
+- [curl_examples.md](curl_examples.md) - Sample API requests using `curl`.
+


### PR DESCRIPTION
## Summary
- add documentation index at `docs/README.md`
- update component path for MCP client
- link to new docs README in Agent Registration section
- show example tool chaining graph in README

## Testing
- `pytest -q` *(fails: command not found)*