### PR TITLE
Implement LLM classification for compass index

### DIFF
--- a/app/utils/setup_compass_index.py
+++ b/app/utils/setup_compass_index.py
@@ -3,61 +3,69 @@ Utility for setting up Cohere Compass index for tool and resource discovery
 """
 
 import logging
-from typing import Dict, Any, List, Optional
+import json
+from pathlib import Path
+from typing import Dict
 import httpx
 from app.config import Config
 from app.registry.tools import get_registered_tools, ToolDefinition
 from app.registry.resources import get_registered_resources
+from app.utils.parameter_extractor import _call_llm
 
 logger = logging.getLogger(__name__)
 
-def derive_intent_from_description(description: str) -> str:
-    """Derive intent from tool description"""
-    description_lower = description.lower()
-    
-    if any(kw in description_lower for kw in ["search", "find", "look for", "locate"]):
-        return "search"
-    elif any(kw in description_lower for kw in ["summarize", "summary", "brief"]):
-        return "summarize"
-    elif any(kw in description_lower for kw in ["analyze", "analysis", "insights"]):
-        return "analyze"
-    elif any(kw in description_lower for kw in ["report", "generate report", "create report"]):
-        return "report"
-    elif any(kw in description_lower for kw in ["document", "file", "read"]):
-        return "document"
-    else:
-        return "general"
+# Path for caching tool classification results
+CACHE_FILE = Path(__file__).resolve().parent.parent / "output" / "tool_classification_cache.json"
 
-def derive_category_from_tool(name: str, tool: ToolDefinition) -> str:
-    """Derive category from tool name and definition"""
-    name_lower = name.lower()
-    description_lower = tool.description.lower()
-    
-    # Check name first
-    if any(kw in name_lower for kw in ["search", "find", "query"]):
-        return "search"
-    elif any(kw in name_lower for kw in ["summarize", "summary"]):
-        return "summarization"
-    elif any(kw in name_lower for kw in ["analyze", "analysis"]):
-        return "analysis"
-    elif any(kw in name_lower for kw in ["report", "generate"]):
-        return "reporting"
-    elif any(kw in name_lower for kw in ["document", "file"]):
-        return "document"
-    
-    # Check description if name doesn't give a clear category
-    if any(kw in description_lower for kw in ["search", "find", "query"]):
-        return "search"
-    elif any(kw in description_lower for kw in ["summarize", "summary"]):
-        return "summarization"
-    elif any(kw in description_lower for kw in ["analyze", "analysis"]):
-        return "analysis"
-    elif any(kw in description_lower for kw in ["report", "generate"]):
-        return "reporting"
-    elif any(kw in description_lower for kw in ["document", "file"]):
-        return "document"
-    
-    return "general"
+
+def _load_cache() -> Dict[str, Dict[str, str]]:
+    """Load classification cache from disk."""
+    if CACHE_FILE.exists():
+        try:
+            return json.loads(CACHE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_cache(cache: Dict[str, Dict[str, str]]) -> None:
+    """Persist classification cache to disk."""
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(json.dumps(cache, indent=2))
+
+
+async def classify_tool(tool: ToolDefinition, cache: Dict[str, Dict[str, str]]) -> Dict[str, str]:
+    """Classify a tool's intent and category using an LLM."""
+    if tool.full_name in cache:
+        return cache[tool.full_name]
+
+    system_prompt = (
+        "You label tools with an intent and a short category. "
+        "Respond with JSON using keys 'intent' and 'category'."
+    )
+    user_prompt = f"Tool name: {tool.full_name}\nDescription: {tool.description}"
+
+    try:
+        response = await _call_llm([
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ])
+        start = response.find("{")
+        end = response.rfind("}")
+        if start != -1 and end != -1:
+            data = json.loads(response[start : end + 1])
+        else:
+            data = json.loads(response)
+        intent = data.get("intent", "general")
+        category = data.get("category", "general")
+    except Exception as e:
+        logger.warning(f"LLM classification failed for {tool.full_name}: {e}")
+        intent = "general"
+        category = "general"
+
+    cache[tool.full_name] = {"intent": intent, "category": category}
+    _save_cache(cache)
+    return cache[tool.full_name]
 
 async def setup_compass_index():
     """Set up Cohere Compass index for tool and resource discovery"""
@@ -70,13 +78,15 @@ async def setup_compass_index():
         # Get all tools and resources
         tools = get_registered_tools()
         resources = get_registered_resources()
+
+        cache: Dict[str, Dict[str, str]] = _load_cache()
         
         # Prepare documents for indexing
         documents = []
         
         # Add tools
         for tool in tools:
-            # Create document for tool
+            classification = await classify_tool(tool, cache)
             doc = {
                 "id": f"tool:{tool.full_name}",
                 "type": "tool",
@@ -84,17 +94,17 @@ async def setup_compass_index():
                     "name": tool.full_name,
                     "description": tool.description,
                     "parameters": tool.input_schema,
-                    "intent": derive_intent_from_description(tool.description),
-                    "category": derive_category_from_tool(tool.full_name, tool),
+                    "intent": classification.get("intent", "general"),
+                    "category": classification.get("category", "general"),
                     "namespace": tool.namespace,
-                    "metadata": tool.metadata
+                    "metadata": tool.metadata,
                 },
                 "text": f"Tool: {tool.full_name} - {tool.description}",
                 "metadata": {
                     "type": "tool",
                     "namespace": tool.namespace,
-                    "description": tool.description
-                }
+                    "description": tool.description,
+                },
             }
             documents.append(doc)
         


### PR DESCRIPTION
## Summary
- classify tools using an LLM in `setup_compass_index.py`
- remove heuristic intent/category derivation
- cache classification results to avoid repeated calls

## Testing
- `pytest -q` *(fails: command not found)*