### PR TITLE
Fix circular import in MCPBridge

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -94,8 +94,7 @@ try:
     from app.mcp_bridge import MCPBridge
 
     # Create a bridge instance
-    bridge = MCPBridge()
-    bridge.mcp = mcp
+    bridge = MCPBridge(mcp)
     logger.info("MCP-Bridge initialized Successfully")
 except Exception as e:
     logger.error(f"MCP-Bridge initialization failed: {e}")


### PR DESCRIPTION
## Summary
- avoid circular imports by lazily importing mcp_server in MCPBridge
- pass `mcp` explicitly when creating MCPBridge inside mcp_server

## Testing
- `pytest tests/test_plan_tool_chain.py::test_plan_success -q`
- `pytest tests/test_plan_tool_chain.py::test_plan_fallback -q`
