### PR TITLE
Refactor LLM helper usage

### DIFF
--- a/docs/code_walkthrough.md
+++ b/docs/code_walkthrough.md
@@ -43,7 +43,7 @@ Key function:
 Extracts tool parameters from natural language queries.
 
 Key functions:
-- `_call_llm` – minimal LLM wrapper used only for parameter extraction.
+- `_call_llm` – minimal LLM wrapper used for parameter extraction and planning.
 - `extract_parameters_with_llm` – high level routine that formats the prompt and normalises the output.
 
 ### `app/registry/tools.py`
@@ -59,7 +59,7 @@ The SDK (`MCPClient`) allows other Python code to query the MCP server.  Command
 ## LLM Wrapper Functions
 The repository has several small functions that directly interact with the LLM service:
 
-1. `app/utils/parameter_extractor.py:_call_llm` – used when extracting parameters for a tool.
+1. `app/utils/parameter_extractor.py:_call_llm` – shared helper used by planning and parameter extraction.
 2. `app/client.py:call_llm` – the main wrapper for MCP server interactions.
 3. `ui/app.py:call_llm` – similar wrapper used by the Chainlit UI.
 

--- a/tests/test_plan_tool_chain.py
+++ b/tests/test_plan_tool_chain.py
@@ -1,13 +1,12 @@
 import asyncio
 from unittest.mock import patch
-import app.mcp_bridge as mcp_bridge
 from app.mcp_bridge import MCPBridge
 
 async def show_success():
     async def fake_call(messages):
         return '[{"tool": "search_docs", "parameters": {"query": "policy"}}]'
 
-    with patch.object(mcp_bridge, "_call_llm", side_effect=fake_call), \
+    with patch.object(MCPBridge, "_call_llm", side_effect=fake_call), \
          patch.object(MCPBridge, "_log_plan", lambda self, plan: None):
 
         bridge = MCPBridge()
@@ -24,7 +23,7 @@ async def show_fallback():
             "endpoints": [{"type": "tool", "name": "server_info", "params": {}}],
         }
 
-    with patch.object(mcp_bridge, "_call_llm", side_effect=bad_call), \
+    with patch.object(MCPBridge, "_call_llm", side_effect=bad_call), \
          patch.object(MCPBridge, "_log_plan", lambda self, plan: None), \
          patch.object(MCPBridge, "route_request", dummy_route):
 


### PR DESCRIPTION
## Summary
- alias `_call_llm` import for backward compatibility
- expose `_call_llm` helper as a method on `MCPBridge`
- update planning logic to call the method
- patch docs to clarify `_call_llm` usage
- adjust plan tool chain demo test to patch the method

## Testing
- `pytest tests/test_plan_tool_chain.py -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `PYTHONPATH=. python tests/test_plan_tool_chain.py` *(fails: ModuleNotFoundError: No module named 'rbc_security')*