### PR TITLE
Fix tool registration warning

### DIFF
--- a/app/tools/clientview_financials.py
+++ b/app/tools/clientview_financials.py
@@ -503,11 +503,13 @@ def register_tools(mcp):
         system_prompt="You are an expert CRM analyst specializing in client revenue analysis and relationship management."
     )
     @mcp.tool()
-    async def get_top_clients(ctx: Context, **kwargs) -> str:
-        currency = kwargs.get("currency", "USD")
-        sorting = kwargs.get("sorting", "top")
-        region = kwargs.get("region")
-        focus_list = kwargs.get("focus_list")
+    async def get_top_clients(
+        ctx: Context,
+        sorting: str = "top",
+        currency: str = "USD",
+        region: str | None = None,
+        focus_list: str | None = None,
+    ) -> str:
         """
         Get top clients by revenue.
         

--- a/project-docs/flow.md
+++ b/project-docs/flow.md
@@ -91,7 +91,7 @@ graph LR
 - **Example Tool**:
   ```python
   @register_tool(namespace="crm")
-  async def get_top_clients(ctx: Context, **kwargs):
+  async def get_top_clients(ctx: Context, sorting: str = "top", currency: str = "USD", region: str | None = None, focus_list: str | None = None):
       # 1. Executes business logic
       # 2. Returns formatted results
   ```


### PR DESCRIPTION
## Summary
- remove kwargs from `get_top_clients` tool
- update docs example accordingly

## Testing
- `pytest tests/test_mcp_server.py::test_server -q` *(fails: ModuleNotFoundError: No module named 'fastmcp')*