### PR TITLE
Add documentation for server_info output

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ This directory contains additional documentation for the MCP Server.
 - [docker_usage.md](docker_usage.md) - Instructions for building and running the container image.
 - [curl_examples.md](curl_examples.md) - Sample API requests using `curl`.
 - [langchain_bridge.md](langchain_bridge.md) - Notes on using LangChain agents for planning.
+- [server_info_format.md](server_info_format.md) - Example output from the `server_info` tool.

--- a/docs/server_info_format.md
+++ b/docs/server_info_format.md
@@ -1,0 +1,32 @@
+# `server_info` Output Format
+
+The `server_info` tool returns Markdown describing the server configuration and all registered tools. Tools are grouped by namespace and show their input parameters as bullet lists.
+
+## Example Output
+
+```markdown
+# MCP Server Information
+**Host**: localhost
+**Port**: 8080
+
+\U0001F4E6 Available MCP Tools
+
+### finance
+\U0001F527 `validate_company`
+Description: Validate if a company exists and return standardized info
+Inputs:
+- `company_id`: string – Ticker or company identifier
+
+\U0001F527 `validate_currency`
+Description: Validate currency code and optionally convert amount
+Inputs:
+- `amount`: number – Amount to validate
+- `currency`: string – Currency code
+- `target_currency`: string – Target currency for conversion
+
+### document
+\U0001F527 `summarize_doc`
+Description: Summarize a specific document by name
+Inputs:
+- `doc_name`: string – Name of the document
+```


### PR DESCRIPTION
## Summary
- document `server_info` output format and example
- link the new docs from the docs index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'botocore')*