### PR TITLE
Add LangChain dependency required for LangChainBridge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pandas>=2.0.0",
     "openai>=1.0.0",
     "cohere>=4.32",
+    "langchain>=0.3.25",
     "anthropic>=0.5,<1.0.0",
     "boto3>=1.28.62",
     "markdown>=3.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ click>=8.0.0
 fastmcp>=0.1.0
 openai>=1.0.0
 cohere>=4.32
+langchain>=0.3.25
 # Pin anthropic below 1.0 for Python 3.11 compatibility
 anthropic>=0.5,<1.0.0
 


### PR DESCRIPTION
## Summary
- add `langchain` to `[project]` dependencies in `pyproject.toml`
- mirror the langchain requirement in `requirements.txt`

## Testing
- `pytest -q` *(fails: 229 errors during collection)*