### PR TITLE
Add docker entrypoint usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ COPY ui/ ./ui/
 COPY run.py .
 COPY requirements.txt .
 COPY artifacts/ ./artifacts/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Install dependencies
 RUN pip install --upgrade pip --timeout 60
@@ -91,4 +93,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8000/api/v1/health || exit 1
 
 # Start application
-CMD ["python", "run.py"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- copy `docker-entrypoint.sh` into the container and mark executable
- use the script as the container entrypoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cfbd46730832994bbdf69db093bec